### PR TITLE
docs(ci): add install instructions to the pre-release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,5 +137,38 @@ jobs:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: Pre-release ${{ steps.tag.outputs.tag }}
           prerelease: true
+          body: |
+            ## Install
+
+            ### Linux
+
+            The artifact is an [AppImage](https://appimage.org/) — a single self-contained executable. Download it, extract, and drop it on your `PATH` as `lgpm` (swap `x86_64` for `aarch64` on ARM):
+
+            ```bash
+            wget https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.tag }}/lgpm-x86_64-linux.tar.gz
+            tar -xvf lgpm-x86_64-linux.tar.gz
+            mkdir -p ~/.local/bin
+            install -m755 lgpm-x86_64.AppImage ~/.local/bin/lgpm
+            # make sure ~/.local/bin is on your PATH (add this to ~/.bashrc or ~/.zshrc):
+            export PATH="$HOME/.local/bin:$PATH"
+            ```
+
+            Now `lgpm` runs from anywhere. (If you hit a FUSE error, run it as `APPIMAGE_EXTRACT_AND_RUN=1 lgpm`.)
+
+            ### macOS (Apple Silicon)
+
+            > **Download from the terminal with `wget` or `curl` — _not_ a web browser.** Browsers tag downloads with `com.apple.quarantine`, which makes Gatekeeper block this unsigned binary. Fetching over the terminal and extracting with `tar` never sets that flag, so the binary runs as-is — no signing or notarization needed.
+
+            ```bash
+            wget https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.tag }}/lgpm-aarch64-macos.tar.gz
+            tar -xvf lgpm-aarch64-macos.tar.gz
+            # move the whole folder somewhere permanent (keep its contents together —
+            # the binary finds its libraries via ../lib) and put its bin/ on your PATH:
+            mv lgpm-aarch64-macos ~/.local/lgpm
+            echo 'export PATH="$HOME/.local/lgpm/bin:$PATH"' >> ~/.zshrc
+            source ~/.zshrc
+            ```
+
+            Now `lgpm` runs from anywhere.
           files: |
             artifacts/*.tar.gz


### PR DESCRIPTION
Follow-up to #18 (the install-instructions body didn't make it into that squash-merge).

Adds an **Install** section to the GitHub pre-release body (the `softprops/action-gh-release` step) with copy-pasteable commands built from `${{ github.repository }}` + the release tag:

- **Linux** — extract the AppImage tarball, `install -m755 …AppImage ~/.local/bin/lgpm`, put `~/.local/bin` on `PATH` → run `lgpm` from anywhere.
- **macOS** — download with `wget`/`curl` (terminal downloads never set `com.apple.quarantine`, unlike browsers, so the unsigned binary runs without signing/notarization), `tar -xvf`, then add the extracted `bin/` to `PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)