### PR TITLE
fix: use the shared semver implementation, and stop clobbering newer packages

### DIFF
--- a/cmd/main.cpp
+++ b/cmd/main.cpp
@@ -1,9 +1,12 @@
+#include <algorithm>
 #include <filesystem>
 #include <iostream>
 #include <nlohmann/json.hpp>
 #include <string>
 #include <vector>
 
+#include "lgx.h"
+#include "logos/semver.hpp"
 #include "package_manager_lib.h"
 #include "package_manager_json.h"
 #include "version_info.h"
@@ -118,10 +121,43 @@ static int cmdInstallDir(PackageManagerLib& pm, const std::string& dirPath) {
         return 1;
     }
 
-    std::sort(lgxFiles.begin(), lgxFiles.end());
+    // Install order matters: installPluginFile() overwrites, so within one
+    // package name the LAST install wins. Sorting the raw paths ordered
+    // "foo-1.10.0.lgx" before "foo-1.9.0.lgx" (lexicographically "1" < "9"), so
+    // the older 1.9.0 was installed last and clobbered the newer one. Order by
+    // the package's real (name, version) read from the archive, version
+    // ascending, so the newest of each package lands last.
+    struct Candidate {
+        fs::path    path;
+        std::string name;
+        std::string version;
+    };
+
+    std::vector<Candidate> candidates;
+    candidates.reserve(lgxFiles.size());
+    for (const auto& p : lgxFiles) {
+        Candidate c{p, {}, {}};
+        if (lgx_package_t pkg = lgx_load(p.string().c_str())) {
+            if (const char* n = lgx_get_name(pkg)) c.name = n;
+            if (const char* v = lgx_get_version(pkg)) c.version = v;
+            lgx_free_package(pkg);
+        }
+        // An unreadable package keeps an empty name/version: it sorts first and
+        // fails below with a proper error, rather than being silently dropped.
+        candidates.push_back(std::move(c));
+    }
+
+    std::sort(candidates.begin(), candidates.end(),
+              [](const Candidate& a, const Candidate& b) {
+                  if (a.name != b.name) return a.name < b.name;
+                  const int c = logos::semver::compare(a.version, b.version);
+                  if (c != 0) return c < 0;
+                  return a.path < b.path;  // deterministic tiebreak
+              });
 
     int failures = 0;
-    for (const auto& lgxPath : lgxFiles) {
+    for (const auto& candidate : candidates) {
+        const fs::path& lgxPath = candidate.path;
         std::cout << "Installing " << lgxPath.filename().string() << "..." << std::flush;
 
         std::string errorMsg;

--- a/flake.lock
+++ b/flake.lock
@@ -100,11 +100,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784064689,
-        "narHash": "sha256-vXyV1NJL6S/FHXWxfVPuOTnAE4U+UKwSyoBRYoLVUZc=",
+        "lastModified": 1784140006,
+        "narHash": "sha256-Pcpku7qHRkDgEiWfFRJ/4dCF7m4MzS138dwv8PgmlNU=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "cba119c08a377621ffa14994901e49f5f8d82f5e",
+        "rev": "8d4236f9453bce8b44dfd2f85a5006af993b7ed2",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -100,11 +100,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784062467,
-        "narHash": "sha256-WhmfrFrvcsj3I3sSuoNWb2hkJn/Ir/fRcNav5WQpd2E=",
+        "lastModified": 1784064689,
+        "narHash": "sha256-vXyV1NJL6S/FHXWxfVPuOTnAE4U+UKwSyoBRYoLVUZc=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "9642c98304233f6c8344220c93b3e13768be8a38",
+        "rev": "cba119c08a377621ffa14994901e49f5f8d82f5e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -100,11 +100,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781873979,
-        "narHash": "sha256-Z5XUSB9wfdrmQhG/0fehJeBd9CjrlIEeO+mKDhE46H4=",
+        "lastModified": 1784062467,
+        "narHash": "sha256-WhmfrFrvcsj3I3sSuoNWb2hkJn/Ir/fRcNav5WQpd2E=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "c207525d30f48620696668c38486884bad5384bc",
+        "rev": "9642c98304233f6c8344220c93b3e13768be8a38",
         "type": "github"
       },
       "original": {

--- a/src/package_manager_lib.cpp
+++ b/src/package_manager_lib.cpp
@@ -14,6 +14,7 @@
 #include <unordered_set>
 #include <nlohmann/json.hpp>
 #include "lgx.h"
+#include "logos/semver.hpp"
 
 namespace fs = std::filesystem;
 using json = nlohmann::json;
@@ -56,16 +57,11 @@ const char* dependencyStatusToString(DependencyStatus s) {
 
 bool PackageManagerLib::versionGreaterOrEqual(const std::string& a, const std::string& b)
 {
-    auto ap = splitString(a, '.');
-    auto bp = splitString(b, '.');
-    size_t len = std::max(ap.size(), bp.size());
-    for (size_t i = 0; i < len; ++i) {
-        int av = i < ap.size() ? std::atoi(ap[i].c_str()) : 0;
-        int bv = i < bp.size() ? std::atoi(bp[i].c_str()) : 0;
-        if (av != bv)
-            return av > bv;
-    }
-    return true; // equal
+    // Delegates to the shared implementation in logos-package. This used to
+    // split on '.' and atoi() each component, which parsed "1.0.0-rc1" as
+    // 1.0.0 — so a pre-release compared equal to its own release and the
+    // skipIfNotNewerVersion gate below refused to install over it.
+    return logos::semver::greater_or_equal(a, b);
 }
 
 PackageManagerLib::PackageManagerLib()

--- a/tests/test_version.cpp
+++ b/tests/test_version.cpp
@@ -41,3 +41,52 @@ TEST(VersionTest, ShortVersionGreater) {
 TEST(VersionTest, EmptyVersions) {
     EXPECT_TRUE(PackageManagerLib::versionGreaterOrEqual("", ""));
 }
+
+// ─────────────────────────── pre-releases ───────────────────────────
+//
+// versionGreaterOrEqual now delegates to the shared implementation in
+// logos-package (include/logos/semver.hpp). It used to split on '.' and atoi()
+// each component, so "1.0.0-rc1" parsed as 1.0.0 and every pre-release compared
+// EQUAL to its own release — meaning `install --skip-if-not-newer` refused to
+// upgrade a 1.0.0-rc1 to the real 1.0.0.
+//
+// Exhaustive precedence coverage lives in logos-package's test_semver.cpp; these
+// pin the behaviour this gate actually depends on.
+
+TEST(VersionTest, ReleaseIsNewerThanItsPreRelease) {
+    EXPECT_TRUE(PackageManagerLib::versionGreaterOrEqual("1.0.0", "1.0.0-rc.1"));
+    EXPECT_FALSE(PackageManagerLib::versionGreaterOrEqual("1.0.0-rc.1", "1.0.0"));
+}
+
+// The reported bug: numeric pre-release identifiers compare numerically, so
+// rc.11 is newer than rc.2 (a plain string compare says the opposite).
+TEST(VersionTest, NumericPreReleaseIdentifiersCompareNumerically) {
+    EXPECT_TRUE(PackageManagerLib::versionGreaterOrEqual("1.0.0-rc.11", "1.0.0-rc.2"));
+    EXPECT_FALSE(PackageManagerLib::versionGreaterOrEqual("1.0.0-rc.2", "1.0.0-rc.11"));
+    EXPECT_TRUE(PackageManagerLib::versionGreaterOrEqual("1.0.0-beta.11", "1.0.0-beta.2"));
+}
+
+TEST(VersionTest, PreReleaseOrderingAcrossIdentifiers) {
+    EXPECT_TRUE(PackageManagerLib::versionGreaterOrEqual("1.0.0-beta", "1.0.0-alpha"));
+    EXPECT_TRUE(PackageManagerLib::versionGreaterOrEqual("1.0.0-rc.1", "1.0.0-beta.11"));
+    EXPECT_FALSE(PackageManagerLib::versionGreaterOrEqual("1.0.0-alpha", "1.0.0-beta"));
+}
+
+TEST(VersionTest, EqualPreReleasesAreGreaterOrEqual) {
+    EXPECT_TRUE(PackageManagerLib::versionGreaterOrEqual("1.0.0-rc.1", "1.0.0-rc.1"));
+}
+
+// Build metadata is ignored for precedence (spec §10), so these are "equal" and
+// the gate treats an incoming build as not-newer.
+TEST(VersionTest, BuildMetadataIgnored) {
+    EXPECT_TRUE(PackageManagerLib::versionGreaterOrEqual("1.0.0+build.2", "1.0.0+build.1"));
+    EXPECT_TRUE(PackageManagerLib::versionGreaterOrEqual("1.0.0+build.1", "1.0.0+build.2"));
+}
+
+// Comparison stays lenient about partial versions (see DifferentLengths above);
+// unparseable junk sorts below anything real, so a garbage installed version
+// never blocks a genuine upgrade.
+TEST(VersionTest, UnparseableVersionsSortLowest) {
+    EXPECT_TRUE(PackageManagerLib::versionGreaterOrEqual("1.0.0", "banana"));
+    EXPECT_FALSE(PackageManagerLib::versionGreaterOrEqual("banana", "1.0.0"));
+}

--- a/tests/test_version.cpp
+++ b/tests/test_version.cpp
@@ -58,6 +58,17 @@ TEST(VersionTest, ReleaseIsNewerThanItsPreRelease) {
     EXPECT_FALSE(PackageManagerLib::versionGreaterOrEqual("1.0.0-rc.1", "1.0.0"));
 }
 
+// The exact regression the old atoi() split produced: a single-token
+// pre-release with NO dot. "1.0.0-rc1" split on '.' gave ["1","0","0-rc1"],
+// and atoi("0-rc1") == 0, so it compared EQUAL to "1.0.0". "rc.1" (with a dot)
+// wouldn't have reproduced it — the third component would have been a clean
+// "0". Keep this distinct case so a future regression here is caught.
+TEST(VersionTest, SingleTokenPreReleaseIsNewerThanRelease) {
+    EXPECT_TRUE(PackageManagerLib::versionGreaterOrEqual("1.0.0", "1.0.0-rc1"));
+    EXPECT_FALSE(PackageManagerLib::versionGreaterOrEqual("1.0.0-rc1", "1.0.0"));
+    EXPECT_TRUE(PackageManagerLib::versionGreaterOrEqual("1.0.0-beta2", "1.0.0-beta1"));
+}
+
 // The reported bug: numeric pre-release identifiers compare numerically, so
 // rc.11 is newer than rc.2 (a plain string compare says the opposite).
 TEST(VersionTest, NumericPreReleaseIdentifiersCompareNumerically) {


### PR DESCRIPTION
Part of a 6-PR chain unifying semver handling. **Depends on logos-co/logos-package#30** (the shared implementation).

## Two bugs

**1. Pre-releases compared equal to their own release.**

`versionGreaterOrEqual` split on `.` and `atoi()`'d each component. `atoi("0-rc1") == 0`, so `1.0.0-rc1` parsed as `1.0.0`:

```cpp
int av = i < ap.size() ? std::atoi(ap[i].c_str()) : 0;   // "0-rc1" -> 0
```

So `install --skip-if-not-newer` saw `1.0.0-rc1` and `1.0.0` as the same version and **refused to upgrade a release candidate to the actual release**. It now delegates to the shared implementation in logos-package (`include/logos/semver.hpp`) — the same code lgx, lgpd and the package-manager UI use. The `lgpm_version_gte` C ABI is unchanged.

**2. `install --dir` installed older packages *over* newer ones.**

The `.lgx` files were sorted by **filename**, lexicographically:

```cpp
std::sort(lgxFiles.begin(), lgxFiles.end());
```

`installPluginFile()` overwrites, so within one package name the *last* install wins. And `foo-1.10.0.lgx` sorts before `foo-1.9.0.lgx` (`"1" < "9"`) — so 1.9.0 was installed last and clobbered 1.10.0. Now ordered by the package's real `(name, version)` read from the archive, version ascending, so the newest of each package lands last. An unreadable package keeps an empty name/version, sorts first, and still fails with a proper error rather than being silently dropped.

## Tests

`tests/test_version.cpp` had ten cases and **not one pre-release among them**. Adds the coverage this gate actually depends on: release > its pre-release, `rc.11` > `rc.2` (numeric identifiers compare numerically), ordering across identifiers, build metadata ignored, and unparseable versions sorting lowest.

Exhaustive spec coverage lives in logos-package's `test_semver.cpp`; these pin the behaviour of *this* gate.

Note the existing `DifferentLengths` / `ShortVersionGreater` cases (`"1.0" >= "1.0.0"`) still pass — they're why comparison in the shared header is deliberately lenient about partial versions while validation stays strict.

## Chain

`flake.lock` is pinned at logos-package#30's branch head so CI can build; **re-pin to `master` once #30 merges**. Verified green against that pin (`nix build .#tests`).

Merge order: logos-package#30 → **this** / logos-package-downloader *(parallel)* → package-manager-ui → modules-release-tool → workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)